### PR TITLE
Changed number formatting in awk (scientific notation caused truncate…

### DIFF
--- a/shrinkwrap.sh
+++ b/shrinkwrap.sh
@@ -47,7 +47,7 @@ sudo fdisk -l $1
 sudo fdisk -l $1 > /tmp/fdisk_new.log
 sudo losetup -d /dev/loop0
 
-FINALEND_BYTES=$(cat /tmp/fdisk_new.log | grep "83 Linux" | awk '{print ($3+1)*512}')
+FINALEND_BYTES=$(cat /tmp/fdisk_new.log | grep "83 Linux" | awk '{printf "%.0f",($3+1)*512}')
 echo "TRUNCATE AT: $FINALEND_BYTES bytes"
 
 # Truncate the image file on disk


### PR DESCRIPTION
… to exit with error)

For some reason in Debian Buster (RPI4) awk returns number in scentific notation, e.g.:

```
#nrasp /home/pi/lab/shrinkwrap # cat /tmp/fdisk_new.log | grep "83 Linux" | awk '{print ($3+1)*512}'

4.5216e+09

```

This causes truncate command to exit with error, as it doesn't understand the scentific notation. The workaround is simple to use printf with float format (%d - integer is too small) and cut off decimal places.


